### PR TITLE
default value for opts object

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -9,7 +9,7 @@ function isEventEmitter (o) {
   return typeof o === 'object' && o !== null && typeof o.on === 'function'
 }
 
-module.exports = function getNetworkOptions (opts) {
+module.exports = function getNetworkOptions (opts = {}) {
   if (isEventEmitter(opts)) return opts
   if (!opts.host && !opts.port) return getSocketPath()
   if (opts.host && !opts.port) return getSocketPath(opts.host)


### PR DESCRIPTION
If the opts object is not passed, I'm getting a "cannot read host of undefined" error, which should be fixed by assigning a default opts of {}