### PR TITLE
Fixing error identification

### DIFF
--- a/index.js
+++ b/index.js
@@ -696,5 +696,5 @@ module.exports = class HRPCSession extends HRPC {
 }
 
 function isStreamError (err) {
-  return err.message === 'Writable stream closed prematurely' || err.message === 'Readable stream closed prematurely'
+  return err.message === 'Writable stream closed prematurely' || err.message === 'Readable stream closed before ending'
 }


### PR DESCRIPTION
It seems like the check for the streamx error messages are wrong?

The error messages for the stream identification were mistaken.

_Sidequestion_: What happens if the socket is a node stream?